### PR TITLE
Add php5-mysql to requirements

### DIFF
--- a/fr/requirements.rst
+++ b/fr/requirements.rst
@@ -37,6 +37,7 @@ Sonerezh fonctionne avec le framework PHP CakePHP, PHP est donc indispensable.
 
 * PHP 5.4 ou supérieur
 * Le module PHP GD
+* Le module PHP MYSQL
 
 -----------------
 Libav (optionnel)


### PR DESCRIPTION
It may be obvious that it's necessary but this module is not pulled by any of the requirements.
